### PR TITLE
instance-crowdsec start fails. In some case it works, and in some case

### DIFF
--- a/tests/bats/02_nolapi.bats
+++ b/tests/bats/02_nolapi.bats
@@ -76,7 +76,7 @@ declare stderr
 
 @test "$FILE lapi status shouldn't be ok without api.server" {
     yq 'del(.api.server)' -i "${CONFIG_YAML}"
-    ./instance-crowdsec start
+    ./instance-crowdsec start || true 
     run -1 --separate-stderr cscli machines list
     run -0 echo "$stderr"
     assert_output --partial "Local API is disabled, please run this command on the local API machine"


### PR DESCRIPTION
it does'nt. But what matters with this test is the cscli mahcines list
command fails.